### PR TITLE
[Refactor/37] Job 생성 Redis 분산락 + 멱등성 처리 도입

### DIFF
--- a/docs/complete-upload-idempotency-expert-review.md
+++ b/docs/complete-upload-idempotency-expert-review.md
@@ -1,0 +1,181 @@
+# Complete Upload 중복 Job 방지 방식 전문가 리뷰
+
+## TL;DR
+
+- 현재 `PESSIMISTIC_WRITE` 기반 접근은 **단기적으로 유효한 안전장치**입니다. 실제로 동시성 테스트에서도 중복 Job 생성 억제 효과가 확인됩니다.
+- 다만 이 방식만으로는 "진짜 멱등성"을 완성했다고 보기 어렵습니다. 이유는 **DB 유니크 보장 부재**, **외부 메시지 전송 타이밍**, **재시도/네트워크 중복 요청 시 API 계약 부재** 때문입니다.
+- 권장 방향은 "락 중심"에서 "**멱등성 중심(상태 전이 + 유니크 키 + outbox/event after commit)**"으로 전환하는 것입니다.
+
+---
+
+## 1) 현행 구현 분석 (As-Is)
+
+### 1.1 요청 처리 흐름
+
+`CompleteVideoUploadUseCase.execute()`는 아래 순서로 동작합니다.
+
+1. `videoAdaptor.queryByIdWithLock(videoId)`로 비디오 행 비관락 획득  
+   - 참조: `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java:52`  
+   - 참조: `src/main/java/com/example/echoshotx/video/infrastructure/persistence/VideoRepository.java:36`
+2. 상태가 `PENDING_UPLOAD`인지 검사 후 업로드 완료 전환
+3. 크레딧 차감
+4. Job 생성 + SQS 전송 핸들러 호출
+5. Video 상태를 `QUEUED`로 전환
+
+### 1.2 지금 방식의 장점
+
+- **동일 `videoId` 경쟁 요청 직렬화**: 더블 클릭/동시 재시도에서 1건만 통과시키는 데 효과적
+- **구현 난이도 낮음**: 도메인 구조 큰 변경 없이 빠르게 적용 가능
+- **멀티 인스턴스에서도 유효**: DB 락이므로 애플리케이션 인스턴스가 여러 대여도 동작
+
+### 1.3 핵심 한계 및 리스크
+
+1. **락은 멱등성 그 자체가 아님**  
+   락은 "동시 실행 구간" 제어일 뿐, "재시도 요청을 같은 결과로 수렴"시키는 API 계약(멱등 키, 동일 응답 재사용)이 없습니다.
+
+2. **Job 테이블에 중복 불변식(Unique) 부재**  
+   `JobRepository`는 `findByVideoId`만 있고, DB 레벨에서 `video_id` 중복을 막는 제약이 없습니다.  
+   - 참조: `src/main/java/com/example/echoshotx/job/infrastructure/persistence/JobRepository.java:9`
+
+3. **외부 I/O가 트랜잭션 경계와 섞여 있음**  
+   현재 `jobEventHandler.handleCreate(event)`를 직접 호출합니다.  
+   - 참조: `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java:86`  
+   이 메서드는 `@TransactionalEventListener(AFTER_COMMIT)`가 붙어 있지만, "이벤트 발행"이 아니라 "직접 메서드 호출"이므로 실질적으로 즉시 실행됩니다. 결과적으로:
+   - DB 커밋 전 SQS 전송이 일어날 수 있음
+   - 이후 트랜잭션 롤백 시 "DB는 실패했는데 큐에는 메시지 있음" 불일치 가능
+   - 락 보유 시간이 외부 네트워크 지연에 의해 늘어날 수 있음
+
+4. **중복 요청 시 응답이 실패 중심**  
+   현재는 상태가 이미 바뀐 요청에 `VIDEO_ALREADY_PROCESSED`를 던집니다. 기술적으로 맞지만, 멱등 API 관점에서는 "이미 처리됨"을 성공(또는 동일 응답)으로 취급하는 전략이 더 운영 친화적입니다.
+
+5. **크레딧 차감 멱등 키 부재**  
+   크레딧 이력(`credit_history`)에도 "같은 video 처리에 대한 단일 차감"을 강제하는 제약/키가 보이지 않습니다. 현재는 락과 상태 전이에 의존합니다.
+
+---
+
+## 2) 질문에 대한 직접 답변: "비관적 락이 옳은가?"
+
+### 결론
+
+- **단기 대응책으로는 옳습니다.**
+- **장기 정답으로는 불충분합니다.**
+
+즉, 현재 선택은 "나쁜 선택"이 아니라 "1차 방어선"입니다. 다만 실무에서 장애/재시도/부분실패를 고려하면, 락 하나에 핵심 정합성을 맡기는 구조는 유지비가 커집니다.
+
+---
+
+## 3) 대안(멱등성 처리) 비교
+
+## 3.1 상태 전이 + 조건부 업데이트 (권장)
+
+아이디어: `PENDING_UPLOAD -> UPLOAD_COMPLETED` 전이를 **원자적 조건 업데이트**로 수행합니다.
+
+- 예: `update video set status='UPLOAD_COMPLETED', ... where id=:id and status='PENDING_UPLOAD'`
+- 영향 row 수가 `1`이면 최초 처리 성공, `0`이면 이미 처리됨(멱등 hit)
+
+장점:
+- 락 경합/대기 감소
+- 멱등 판단이 명확
+
+주의:
+- 이후 Job 생성/크레딧까지 포함한 트랜잭션 설계 필요
+
+## 3.2 DB 유니크 제약 기반 단일성 보장 (필수 권장)
+
+아이디어: "한 비디오당 활성 Job 1개" 같은 비즈니스 불변식을 DB로 강제합니다.
+
+- 예: `job(video_id)` 유니크 (혹은 상태 조건 포함한 부분 유니크 인덱스)
+
+장점:
+- 앱 버그/락 누락이 있어도 최종 중복 삽입 차단
+- 운영 중 가장 신뢰도 높은 안전장치
+
+주의:
+- 재처리 정책(FAILED 후 재생성 허용) 반영한 인덱스 설계 필요
+
+## 3.3 Idempotency-Key 테이블 (API 멱등 계약)
+
+아이디어: 클라이언트가 `Idempotency-Key`를 보내고, 서버는 `(memberId, endpoint, key)`로 결과를 저장/재사용합니다.
+
+장점:
+- 네트워크 재시도/타임아웃 후 재호출에 동일 응답 보장
+- UX/모바일 환경에서 매우 유리
+
+주의:
+- 저장 TTL/응답 스냅샷 관리 필요
+
+## 3.4 Outbox 패턴 + 커밋 후 발행 (강력 권장)
+
+아이디어: 트랜잭션 내에서 outbox 레코드 저장 후, 별도 퍼블리셔가 커밋된 이벤트만 SQS 발행.
+
+장점:
+- DB 상태와 메시지 발행 불일치 최소화
+- 재시도/복구 표준화
+
+주의:
+- 운영 컴포넌트(폴러/리트라이) 추가 필요
+
+## 3.5 Redis 분산락
+
+장점:
+- 특정 고경합 구간에서 빠른 제어 가능
+
+한계:
+- DB 정합성 보장을 대체하지 못함
+- 락 유실/만료/펜싱 토큰 등 추가 복잡도
+
+실무 판단: 이 케이스에서는 DB row 단위 정합성이 핵심이므로 우선순위 낮음.
+
+---
+
+## 4) 이 프로젝트에 맞는 권장 아키텍처 (현실적인 순서)
+
+### Phase 1 (빠른 안정화)
+
+1. `job.video_id` 단일성 제약 추가 (정책에 맞는 unique)
+2. 중복 요청 시 `VIDEO_ALREADY_PROCESSED`를 무조건 에러로 끝내지 말고, 상태가 `UPLOAD_COMPLETED/QUEUED/PROCESSING`이면 기존 결과를 반환하는 멱등 응답 정책 추가
+3. `CompleteVideoUploadUseCase`에서 `JobCreatedEvent` 직접 호출 제거, 실제 `ApplicationEventPublisher.publishEvent(...)`로 바꾸고 `AFTER_COMMIT`에서만 SQS 발행
+
+### Phase 2 (정석 멱등성)
+
+1. `Idempotency-Key` 도입 (`POST /videos/{videoId}/complete-upload`)
+2. 키-응답 저장소(테이블/Redis) 도입
+3. 재호출 시 동일 응답 반환 (HTTP 200/201 일관 정책)
+
+### Phase 3 (내구성 강화)
+
+1. Outbox 패턴 도입
+2. 소비자(Worker) 쪽도 `jobId` 기준 멱등 처리
+3. 관측성 추가: duplicate-hit, lock-wait, unique-violation, outbox-retry 메트릭
+
+---
+
+## 5) 실무 관점의 날카로운 포인트
+
+1. **락은 비즈니스 규칙이 아니라 동시성 제어 도구**입니다. 비즈니스 불변식은 반드시 DB 제약으로 닫아야 합니다.
+2. **"정상 실패"를 줄여야 운영이 편해집니다.** 더블 클릭/재시도는 사용자 잘못이 아니라 네트워크 현실입니다. 이 경우 멱등 성공 응답이 UX/재시도 정책에 더 적합합니다.
+3. **외부 메시징은 커밋 이후**가 원칙입니다. 현재 구조는 롤백 불일치 가능성이 있어 장애 시 디버깅 비용이 큽니다.
+4. **크레딧은 돈입니다.** 차감/환불은 반드시 "중복 불가 키"를 가져야 합니다. (예: `(member_id, video_id, transaction_type=USAGE)` 제약 또는 비즈니스 키)
+
+---
+
+## 6) 최종 판단
+
+- 현재 비관적 락 적용은 "문제를 빨리 막은 좋은 1차 조치"입니다.
+- 그러나 프로덕션 품질의 멱등성으로 가려면, 다음 3가지는 필수입니다.
+  1. **DB 유니크 제약으로 중복 생성 원천 차단**
+  2. **커밋 후 이벤트 발행(또는 Outbox)으로 상태/메시지 정합성 확보**
+  3. **API Idempotency-Key로 재시도 요청 동일 결과 보장**
+
+이 3가지를 적용하면, 더블 클릭뿐 아니라 재시도 폭주/부분 실패/네트워크 타임아웃까지 안정적으로 커버할 수 있습니다.
+
+---
+
+## 참고 코드 위치
+
+- `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java`
+- `src/main/java/com/example/echoshotx/video/infrastructure/persistence/VideoRepository.java`
+- `src/main/java/com/example/echoshotx/job/infrastructure/persistence/JobRepository.java`
+- `src/main/java/com/example/echoshotx/job/application/handler/JobEventHandler.java`
+- `src/main/java/com/example/echoshotx/credit/application/service/CreditService.java`
+- `src/test/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCaseConcurrencyTest.java`

--- a/docs/complete-upload-idempotency-expert-review.md
+++ b/docs/complete-upload-idempotency-expert-review.md
@@ -1,181 +1,347 @@
-# Complete Upload 중복 Job 방지 방식 전문가 리뷰
+# Complete Upload 멱등성/중복 방지 아키텍처 최종 검토서
 
-## TL;DR
+## 0. 문서 목적
 
-- 현재 `PESSIMISTIC_WRITE` 기반 접근은 **단기적으로 유효한 안전장치**입니다. 실제로 동시성 테스트에서도 중복 Job 생성 억제 효과가 확인됩니다.
-- 다만 이 방식만으로는 "진짜 멱등성"을 완성했다고 보기 어렵습니다. 이유는 **DB 유니크 보장 부재**, **외부 메시지 전송 타이밍**, **재시도/네트워크 중복 요청 시 API 계약 부재** 때문입니다.
-- 권장 방향은 "락 중심"에서 "**멱등성 중심(상태 전이 + 유니크 키 + outbox/event after commit)**"으로 전환하는 것입니다.
+이 문서는 `POST /videos/{videoId}/complete-upload`의 중복 요청(더블 클릭, 네트워크 재시도, 멀티 인스턴스 동시 처리) 문제에 대해,
 
----
+- 왜 특정 기술 조합을 채택해야 하는지,
+- 다른 대안은 왜 단독으로 부족한지,
+- 엣지 케이스에서 어떻게 실패하지 않는지,
+- 기술 면접/아키텍처 리뷰에서 받는 날카로운 질문까지
 
-## 1) 현행 구현 분석 (As-Is)
-
-### 1.1 요청 처리 흐름
-
-`CompleteVideoUploadUseCase.execute()`는 아래 순서로 동작합니다.
-
-1. `videoAdaptor.queryByIdWithLock(videoId)`로 비디오 행 비관락 획득  
-   - 참조: `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java:52`  
-   - 참조: `src/main/java/com/example/echoshotx/video/infrastructure/persistence/VideoRepository.java:36`
-2. 상태가 `PENDING_UPLOAD`인지 검사 후 업로드 완료 전환
-3. 크레딧 차감
-4. Job 생성 + SQS 전송 핸들러 호출
-5. Video 상태를 `QUEUED`로 전환
-
-### 1.2 지금 방식의 장점
-
-- **동일 `videoId` 경쟁 요청 직렬화**: 더블 클릭/동시 재시도에서 1건만 통과시키는 데 효과적
-- **구현 난이도 낮음**: 도메인 구조 큰 변경 없이 빠르게 적용 가능
-- **멀티 인스턴스에서도 유효**: DB 락이므로 애플리케이션 인스턴스가 여러 대여도 동작
-
-### 1.3 핵심 한계 및 리스크
-
-1. **락은 멱등성 그 자체가 아님**  
-   락은 "동시 실행 구간" 제어일 뿐, "재시도 요청을 같은 결과로 수렴"시키는 API 계약(멱등 키, 동일 응답 재사용)이 없습니다.
-
-2. **Job 테이블에 중복 불변식(Unique) 부재**  
-   `JobRepository`는 `findByVideoId`만 있고, DB 레벨에서 `video_id` 중복을 막는 제약이 없습니다.  
-   - 참조: `src/main/java/com/example/echoshotx/job/infrastructure/persistence/JobRepository.java:9`
-
-3. **외부 I/O가 트랜잭션 경계와 섞여 있음**  
-   현재 `jobEventHandler.handleCreate(event)`를 직접 호출합니다.  
-   - 참조: `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java:86`  
-   이 메서드는 `@TransactionalEventListener(AFTER_COMMIT)`가 붙어 있지만, "이벤트 발행"이 아니라 "직접 메서드 호출"이므로 실질적으로 즉시 실행됩니다. 결과적으로:
-   - DB 커밋 전 SQS 전송이 일어날 수 있음
-   - 이후 트랜잭션 롤백 시 "DB는 실패했는데 큐에는 메시지 있음" 불일치 가능
-   - 락 보유 시간이 외부 네트워크 지연에 의해 늘어날 수 있음
-
-4. **중복 요청 시 응답이 실패 중심**  
-   현재는 상태가 이미 바뀐 요청에 `VIDEO_ALREADY_PROCESSED`를 던집니다. 기술적으로 맞지만, 멱등 API 관점에서는 "이미 처리됨"을 성공(또는 동일 응답)으로 취급하는 전략이 더 운영 친화적입니다.
-
-5. **크레딧 차감 멱등 키 부재**  
-   크레딧 이력(`credit_history`)에도 "같은 video 처리에 대한 단일 차감"을 강제하는 제약/키가 보이지 않습니다. 현재는 락과 상태 전이에 의존합니다.
+논리적으로 방어 가능한 수준으로 정리한 최종 의사결정 자료입니다.
 
 ---
 
-## 2) 질문에 대한 직접 답변: "비관적 락이 옳은가?"
+## 1. 결론 (Executive Decision)
 
-### 결론
+최종 권장안은 다음 4요소 결합입니다.
 
-- **단기 대응책으로는 옳습니다.**
-- **장기 정답으로는 불충분합니다.**
+1. `Redis 분산락` (진입 경합 완화)
+2. `DB 유니크 제약` (중복 생성 최종 차단)
+3. `멱등 응답 계약` (재시도 요청 동일 결과 수렴)
+4. `커밋 후 발행` (`AFTER_COMMIT` 또는 Outbox) (상태-메시지 정합성)
 
-즉, 현재 선택은 "나쁜 선택"이 아니라 "1차 방어선"입니다. 다만 실무에서 장애/재시도/부분실패를 고려하면, 락 하나에 핵심 정합성을 맡기는 구조는 유지비가 커집니다.
-
----
-
-## 3) 대안(멱등성 처리) 비교
-
-## 3.1 상태 전이 + 조건부 업데이트 (권장)
-
-아이디어: `PENDING_UPLOAD -> UPLOAD_COMPLETED` 전이를 **원자적 조건 업데이트**로 수행합니다.
-
-- 예: `update video set status='UPLOAD_COMPLETED', ... where id=:id and status='PENDING_UPLOAD'`
-- 영향 row 수가 `1`이면 최초 처리 성공, `0`이면 이미 처리됨(멱등 hit)
-
-장점:
-- 락 경합/대기 감소
-- 멱등 판단이 명확
-
-주의:
-- 이후 Job 생성/크레딧까지 포함한 트랜잭션 설계 필요
-
-## 3.2 DB 유니크 제약 기반 단일성 보장 (필수 권장)
-
-아이디어: "한 비디오당 활성 Job 1개" 같은 비즈니스 불변식을 DB로 강제합니다.
-
-- 예: `job(video_id)` 유니크 (혹은 상태 조건 포함한 부분 유니크 인덱스)
-
-장점:
-- 앱 버그/락 누락이 있어도 최종 중복 삽입 차단
-- 운영 중 가장 신뢰도 높은 안전장치
-
-주의:
-- 재처리 정책(FAILED 후 재생성 허용) 반영한 인덱스 설계 필요
-
-## 3.3 Idempotency-Key 테이블 (API 멱등 계약)
-
-아이디어: 클라이언트가 `Idempotency-Key`를 보내고, 서버는 `(memberId, endpoint, key)`로 결과를 저장/재사용합니다.
-
-장점:
-- 네트워크 재시도/타임아웃 후 재호출에 동일 응답 보장
-- UX/모바일 환경에서 매우 유리
-
-주의:
-- 저장 TTL/응답 스냅샷 관리 필요
-
-## 3.4 Outbox 패턴 + 커밋 후 발행 (강력 권장)
-
-아이디어: 트랜잭션 내에서 outbox 레코드 저장 후, 별도 퍼블리셔가 커밋된 이벤트만 SQS 발행.
-
-장점:
-- DB 상태와 메시지 발행 불일치 최소화
-- 재시도/복구 표준화
-
-주의:
-- 운영 컴포넌트(폴러/리트라이) 추가 필요
-
-## 3.5 Redis 분산락
-
-장점:
-- 특정 고경합 구간에서 빠른 제어 가능
-
-한계:
-- DB 정합성 보장을 대체하지 못함
-- 락 유실/만료/펜싱 토큰 등 추가 복잡도
-
-실무 판단: 이 케이스에서는 DB row 단위 정합성이 핵심이므로 우선순위 낮음.
+핵심 이유:
+- 단일 기술로는 "정합성 + 성능 + 운영경험"을 동시에 만족할 수 없습니다.
+- 이 4요소는 역할이 겹치지 않고, 각자의 실패 모드를 상호 보완합니다.
 
 ---
 
-## 4) 이 프로젝트에 맞는 권장 아키텍처 (현실적인 순서)
+## 2. 현행 코드 기준 진단
 
-### Phase 1 (빠른 안정화)
-
-1. `job.video_id` 단일성 제약 추가 (정책에 맞는 unique)
-2. 중복 요청 시 `VIDEO_ALREADY_PROCESSED`를 무조건 에러로 끝내지 말고, 상태가 `UPLOAD_COMPLETED/QUEUED/PROCESSING`이면 기존 결과를 반환하는 멱등 응답 정책 추가
-3. `CompleteVideoUploadUseCase`에서 `JobCreatedEvent` 직접 호출 제거, 실제 `ApplicationEventPublisher.publishEvent(...)`로 바꾸고 `AFTER_COMMIT`에서만 SQS 발행
-
-### Phase 2 (정석 멱등성)
-
-1. `Idempotency-Key` 도입 (`POST /videos/{videoId}/complete-upload`)
-2. 키-응답 저장소(테이블/Redis) 도입
-3. 재호출 시 동일 응답 반환 (HTTP 200/201 일관 정책)
-
-### Phase 3 (내구성 강화)
-
-1. Outbox 패턴 도입
-2. 소비자(Worker) 쪽도 `jobId` 기준 멱등 처리
-3. 관측성 추가: duplicate-hit, lock-wait, unique-violation, outbox-retry 메트릭
-
----
-
-## 5) 실무 관점의 날카로운 포인트
-
-1. **락은 비즈니스 규칙이 아니라 동시성 제어 도구**입니다. 비즈니스 불변식은 반드시 DB 제약으로 닫아야 합니다.
-2. **"정상 실패"를 줄여야 운영이 편해집니다.** 더블 클릭/재시도는 사용자 잘못이 아니라 네트워크 현실입니다. 이 경우 멱등 성공 응답이 UX/재시도 정책에 더 적합합니다.
-3. **외부 메시징은 커밋 이후**가 원칙입니다. 현재 구조는 롤백 불일치 가능성이 있어 장애 시 디버깅 비용이 큽니다.
-4. **크레딧은 돈입니다.** 차감/환불은 반드시 "중복 불가 키"를 가져야 합니다. (예: `(member_id, video_id, transaction_type=USAGE)` 제약 또는 비즈니스 키)
-
----
-
-## 6) 최종 판단
-
-- 현재 비관적 락 적용은 "문제를 빨리 막은 좋은 1차 조치"입니다.
-- 그러나 프로덕션 품질의 멱등성으로 가려면, 다음 3가지는 필수입니다.
-  1. **DB 유니크 제약으로 중복 생성 원천 차단**
-  2. **커밋 후 이벤트 발행(또는 Outbox)으로 상태/메시지 정합성 확보**
-  3. **API Idempotency-Key로 재시도 요청 동일 결과 보장**
-
-이 3가지를 적용하면, 더블 클릭뿐 아니라 재시도 폭주/부분 실패/네트워크 타임아웃까지 안정적으로 커버할 수 있습니다.
-
----
-
-## 참고 코드 위치
-
+참조 위치:
 - `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java`
 - `src/main/java/com/example/echoshotx/video/infrastructure/persistence/VideoRepository.java`
 - `src/main/java/com/example/echoshotx/job/infrastructure/persistence/JobRepository.java`
 - `src/main/java/com/example/echoshotx/job/application/handler/JobEventHandler.java`
 - `src/main/java/com/example/echoshotx/credit/application/service/CreditService.java`
-- `src/test/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCaseConcurrencyTest.java`
+
+현행의 장점:
+- `PESSIMISTIC_WRITE`로 동시 진입 제어 효과는 확인됨
+
+현행의 구조적 취약점:
+1. `job.video_id` 중복 차단 DB 제약 부재
+2. `@TransactionalEventListener`가 붙은 핸들러를 직접 호출하는 구조(이벤트 발행이 아님)
+3. 재시도 요청에 대한 API 멱등 계약 부재(`Idempotency-Key` 없음)
+4. 중복 요청 시 실패 응답 중심이라 운영/UX 비용 증가
+
+---
+
+## 3. 문제를 정확히 정의한 불변식 (Invariants)
+
+이 API에서 절대 깨지면 안 되는 불변식:
+
+- I1. 동일 `videoId`에 대해 활성 Job은 최대 1개
+- I2. 동일 업로드 완료 요청으로 크레딧이 2번 이상 차감되지 않음
+- I3. DB 트랜잭션 롤백 시 외부 큐 발행 결과가 앞서 나가지 않음
+- I4. 동일 요청 재전송은 실패 폭탄이 아니라 동일 결과로 수렴
+
+평가 기준:
+- Correctness(정합성), Availability(가용성), Operability(운영성), Performance(성능), Simplicity(단순성)
+
+---
+
+## 4. 대안 비교: 왜 이 조합이어야 하는가
+
+## 4.1 단일 기술 대안의 한계
+
+### A. 비관적 락만 사용
+
+장점:
+- 동시 실행 직렬화
+
+한계:
+- 락 획득/해제와 무관한 중복 삽입 버그를 DB가 막지 못함
+- 고경합에서 대기/타임아웃 증가
+- API 멱등 계약 부재
+
+판정: "1차 방어선"으로는 적합, "최종 설계"로는 미흡
+
+### B. Redis 락만 사용
+
+장점:
+- 앱 레벨에서 빠른 경합 완화
+
+한계:
+- 네트워크 분할/락 만료/프로세스 중단 시 정합성 단독 보장 불가
+- 데이터 무결성은 결국 DB 제약이 담당해야 함
+
+판정: 성능 장치로 유효, 무결성 장치로 불충분
+
+### C. DB 유니크만 사용
+
+장점:
+- 정합성 가장 강함
+
+한계:
+- 경합 시 예외 폭증, 사용자 체감 실패 증가
+- 재시도 요청의 UX/계약 문제는 해결하지 못함
+
+판정: 필수이나 단독으론 운영 경험 불완전
+
+### D. Idempotency-Key만 사용
+
+장점:
+- API 재시도 수렴
+
+한계:
+- 내부에서 실제 중복 삽입 방지가 없으면 무의미
+
+판정: 계약 계층으로 필수, 물리적 제약 대체 불가
+
+## 4.2 결론: 다층 방어가 정답
+
+- Redis: "경합 완충"
+- DB Unique: "정합성 최종 보루"
+- Idempotent Response: "재시도 수렴"
+- After-Commit Publish: "비동기 정합성"
+
+이 구성은 실패 모드를 분리하고, 한 층이 실패해도 다른 층이 붕괴를 막습니다.
+
+---
+
+## 5. 기술 선택 근거 (의사결정 매트릭스)
+
+점수: 1(낮음) ~ 5(높음)
+
+| 옵션 | 정합성 | 성능 | 운영성 | 구현난이도 | 총평 |
+|---|---:|---:|---:|---:|---|
+| 비관적 락 단독 | 3 | 2 | 3 | 4 | 단기 응급처치 |
+| Redis 락 단독 | 2 | 4 | 3 | 3 | 성능은 좋으나 무결성 약함 |
+| DB 유니크 단독 | 5 | 3 | 2 | 4 | 정합성은 강하나 UX 거칠음 |
+| Idempotency-Key 단독 | 2 | 4 | 4 | 3 | 계약은 좋으나 최종 차단 부재 |
+| Redis+DB+멱등응답+AfterCommit | 5 | 4 | 5 | 3 | 균형 최적 |
+
+선택 사유 요약:
+- 정합성 5점을 확보하면서도, 사용자/운영 관점 실패 체감을 낮출 수 있는 유일한 조합
+
+---
+
+## 6. 권장 To-Be 설계 상세
+
+## 6.1 요청 처리 시퀀스
+
+1. `Idempotency-Key` 추출
+2. 키 중복 조회
+   - 이미 성공 응답 존재: 즉시 동일 응답 반환
+3. Redis 락 획득 시도 (`video:complete:{videoId}`)
+4. 트랜잭션 시작
+5. Video 상태 확인/전이
+6. Job 생성 시 DB 유니크 적용
+7. 크레딧 차감 + 차감 중복 방지 키 기록
+8. 멱등 응답 스냅샷 저장
+9. 트랜잭션 커밋
+10. 커밋 후 이벤트 발행(또는 outbox consume)
+11. 락 해제
+
+## 6.2 DB 제약 권장안
+
+- `job(video_id)` 유니크 제약
+- 크레딧 중복 방지용 키 도입
+  - 예: `credit_history(deduction_key)` 유니크
+  - `deduction_key = "VIDEO_PROCESSING:" + videoId`
+
+## 6.3 멱등 응답 계약
+
+- 동일 `Idempotency-Key` + 동일 사용자 + 동일 endpoint + 동일 payload hash
+  - 기존 응답 그대로 재반환 (`200 OK`)
+- 동일 키, payload 다름
+  - `409 Conflict`
+
+저장 항목:
+- `idempotency_key`, `member_id`, `endpoint`, `request_hash`, `status_code`, `response_body`, `expires_at`
+
+## 6.4 Redis 락 파라미터 가이드
+
+- wait time: 짧게 (예: 200~500ms)
+- lease/watchdog: 트랜잭션 + 외부 지연을 감안해 충분히
+- 실패 시 동작:
+  - 즉시 500 금지
+  - 멱등 조회 경로로 우회 후 가능한 성공 응답 반환
+
+---
+
+## 7. 엣지 케이스와 방어 전략
+
+## 7.1 사용자 더블 클릭 (수 ms 간격)
+
+- 1차 요청 락 획득/처리
+- 2차 요청은 락 대기 실패 또는 멱등 키 hit
+- 결과: 동일 성공 응답 수렴
+
+## 7.2 앱 타임아웃 후 재전송
+
+- 서버에서 1차 요청은 성공했으나 클라이언트가 응답 못 받음
+- 동일 키 재전송 시 저장된 응답 재반환
+- 결과: 중복 작업 없음, 사용자 체감 정상
+
+## 7.3 Redis 장애
+
+- Redis 락 불가
+- DB 유니크가 최종 방어 수행
+- 결과: 성능은 저하될 수 있어도 정합성 유지
+
+## 7.4 DB 커밋 직전 장애
+
+- 커밋 실패 시 after-commit 발행 안 됨
+- 결과: "메시지 먼저, DB 나중" 불일치 방지
+
+## 7.5 동일 키 다른 payload 공격/오사용
+
+- request hash 불일치 탐지
+- `409 Conflict`
+- 결과: 키 재사용 오염 차단
+
+## 7.6 락 만료 후 중복 진입
+
+- Redis 락 레이어가 놓치더라도 DB 유니크가 중복 insert 차단
+- 결과: 최종 정합성 유지
+
+## 7.7 중복 차감 우려
+
+- 크레딧 차감에 비즈니스 키/유니크 부여
+- 결과: Job과 별개로 금전성 데이터 안전 확보
+
+---
+
+## 8. 면접관/리뷰어 공격 질문 대비 Q&A
+
+Q1. "DB 유니크만 있으면 되지, Redis 왜 필요하죠?"
+- A: 유니크만으로 정합성은 보장되지만, 고경합 시 예외 폭증/재시도 폭증으로 운영비가 큽니다. Redis는 유니크 앞단에서 충돌량을 줄여 p95 지연과 에러율을 낮춥니다.
+
+Q2. "Redis 락이 깨지면 끝 아닌가요?"
+- A: 그래서 Redis를 최종 보장으로 쓰지 않습니다. 최종 보장은 DB 유니크입니다. Redis는 성능 계층입니다.
+
+Q3. "비관적 락과 Redis 락 둘 다 중복 아닌가요?"
+- A: 역할이 다릅니다. 비관적 락은 DB row 직렬화, Redis는 앱 레벨 진입 완화입니다. 다만 최종 설계에서는 DB 유니크를 중심으로 두고, 비관적 락은 축소/제거 검토가 가능합니다.
+
+Q4. "멱등 응답이 왜 필요하죠? 그냥 중복이면 409 주면 되잖아요."
+- A: 모바일/인터넷 환경에서 재시도는 정상 동작입니다. 409 남발은 사용자와 운영자 모두에게 노이즈입니다. 동일 요청은 동일 성공 응답으로 수렴시키는 게 API 품질이 높습니다.
+
+Q5. "AFTER_COMMIT 안 하고 그냥 바로 SQS 보내면 뭐가 문제죠?"
+- A: 트랜잭션 롤백 시 큐에는 작업이 남고 DB에는 상태가 없을 수 있습니다. 장애 복구 난이도가 급증합니다. 외부 발행은 커밋 후가 원칙입니다.
+
+Q6. "Outbox까지 꼭 필요합니까?"
+- A: 트래픽/장애 빈도가 낮으면 `publishEvent + AFTER_COMMIT`으로 시작 가능. 다만 발행 내구성/재처리 가시성이 필요하면 Outbox가 더 강합니다.
+
+Q7. "Idempotency-Key TTL은 얼마가 적절합니까?"
+- A: 클라이언트 재시도 윈도우를 커버해야 하므로 보통 수 시간~24시간. 비즈니스/트래픽/저장비용에 따라 조정하며 만료 정책을 명시해야 합니다.
+
+Q8. "Exactly-once 보장인가요?"
+- A: 분산 시스템에서 end-to-end exactly-once는 매우 비싸고 제한적입니다. 이 설계는 effectively-once(중복 무해화) 목표를 현실적으로 달성합니다.
+
+Q9. "락 타임아웃/네트워크 분할에서 데이터 깨지지 않나요?"
+- A: 깨지지 않게 하는 주체가 DB 유니크와 상태전이 제약입니다. 락은 최적화 레이어로 취급합니다.
+
+Q10. "크레딧은 어떻게 회계적 정합성을 보장합니까?"
+- A: 차감 이벤트에 유니크 비즈니스 키를 둬서 중복 차감 물리 차단, 실패 시 환불도 동일 키 기반으로 상쇄 추적합니다.
+
+---
+
+## 9. 구현 플랜 (강화 버전)
+
+## Phase 1: 스키마 불변식 먼저 잠금
+
+1. `job.video_id` 유니크 제약
+2. `credit_history` 중복 차감 방지 키 추가
+3. 기존 중복 데이터 정리 마이그레이션
+
+완료 기준:
+- 동시 요청에서도 중복 row 물리 삽입 불가
+
+## Phase 2: 멱등 응답 계약 도입
+
+1. `Idempotency-Key` 헤더 도입
+2. idempotency 테이블 추가
+3. request hash 검증 + 동일 응답 재반환
+
+완료 기준:
+- 네트워크 재시도에서 사용자 체감 에러 급감
+
+## Phase 3: Redis 분산락 도입
+
+1. Redisson 락 래퍼 구현
+2. 락 실패 시 멱등 조회 fallback
+3. 락 메트릭/알람 연결
+
+완료 기준:
+- 경합 구간 p95/p99 개선, unique violation 로그 감소
+
+## Phase 4: 커밋 후 발행 정렬
+
+1. `handleCreate` 직접 호출 제거
+2. `ApplicationEventPublisher.publishEvent` 적용
+3. 필요 시 Outbox 확장
+
+완료 기준:
+- 롤백-발행 불일치 재현 불가
+
+## Phase 5: 검증/릴리스
+
+1. 동시성/재시도/장애 주입 테스트
+2. 카나리 배포 + 메트릭 검증
+3. 점진 확대
+
+---
+
+## 10. 검증 시나리오 (테스트 관점)
+
+필수 테스트:
+
+- T1. 20~100 동시 요청, 동일 videoId, 동일 키
+  - 기대: 1건 처리 + 나머지 동일 응답
+- T2. 동일 videoId, 다른 키 난사
+  - 기대: DB 유니크로 1건만 유효
+- T3. Redis down
+  - 기대: 처리량 저하 가능, 정합성 유지
+- T4. 커밋 직전 예외 주입
+  - 기대: 메시지 미발행
+- T5. 동일 키 다른 payload
+  - 기대: 409
+- T6. 타임아웃 후 재요청
+  - 기대: 최초 성공 응답 재반환
+
+관측 지표:
+- lock acquire success/fail
+- idempotency hit ratio
+- unique violation rate
+- complete-upload p95/p99
+- duplicate credit attempt count
+
+---
+
+## 11. 최종 판단
+
+"왜 이 방법이어야 하는가"에 대한 최종 답변:
+
+- 이 문제는 단순 동시성 문제가 아니라, "금전성 write + 비동기 발행 + 재시도 네트워크"가 합쳐진 복합 문제입니다.
+- 따라서 단일 제어점(락 하나, 키 하나, 유니크 하나)으로는 반드시 빈틈이 생깁니다.
+- `Redis + DB Unique + Idempotent Response + After-Commit Publish`는 각 계층의 책임을 분리하여,
+  - 정합성,
+  - 성능,
+  - 운영성,
+  - 사용자 경험
+를 동시에 만족시키는 가장 실무적인 균형점입니다.
+
+즉, 이 선택은 "기술 취향"이 아니라 "불변식 중심 설계"의 결과입니다.

--- a/docs/complete-upload-idempotency-implementation-plan.md
+++ b/docs/complete-upload-idempotency-implementation-plan.md
@@ -1,0 +1,258 @@
+# Complete Upload 멱등성 강화 실제 구현 플랜
+
+## 1. 목적과 완료 기준
+
+## 1.1 목적
+
+`POST /videos/{videoId}/complete-upload`의 중복 호출 상황(더블 클릭, 재시도, 동시 요청)에서 다음을 보장한다.
+
+- 동일 비디오에 대해 Job 1개만 생성
+- 크레딧 중복 차감 방지
+- 동일 요청 재전송 시 동일 응답 반환
+- DB 상태와 메시지 발행의 순서 정합성 보장
+
+## 1.2 Definition of Done
+
+- DB 제약으로 중복 Job 삽입이 물리적으로 불가
+- `Idempotency-Key` 재호출 시 동일 `200` 응답 재반환
+- Redis 장애 시에도 정합성 훼손 없음(DB 제약으로 방어)
+- 커밋 실패 시 SQS 메시지 발행 없음
+- 동시성/재시도 테스트 통과 및 관측 지표 정상
+
+---
+
+## 2. 구현 전략 요약
+
+최종 구조는 `Redis 분산락 + DB 유니크 + 멱등 응답 + 커밋 후 발행`이다.
+
+- Redis 분산락: 경합 완화(성능/예외 폭증 완충)
+- DB 유니크: 중복 생성 최종 차단(정합성 최후 보루)
+- 멱등 응답: 재시도 요청 동일 결과 수렴(API 계약)
+- 커밋 후 발행: 상태-메시지 불일치 방지
+
+---
+
+## 3. 작업 범위와 코드 영향도
+
+## 3.1 주요 수정 대상
+
+- `src/main/java/com/example/echoshotx/video/presentation/controller/VideoController.java`
+- `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java`
+- `src/main/java/com/example/echoshotx/job/domain/entity/Job.java`
+- `src/main/java/com/example/echoshotx/job/infrastructure/persistence/JobRepository.java`
+- `src/main/java/com/example/echoshotx/credit/application/service/CreditService.java`
+- `src/main/java/com/example/echoshotx/job/application/handler/JobEventHandler.java`
+
+신규 컴포넌트(예상):
+
+- Idempotency 엔티티/리포지토리/서비스
+- Redis Lock 유틸(예: `DistributedLockService`)
+- DB 마이그레이션 파일(프로젝트 마이그레이션 체계에 맞춰 생성)
+- 메트릭/로깅 공통 유틸
+
+---
+
+## 4. 단계별 구현 플랜
+
+## Phase 0. 사전 정리 (0.5~1일)
+
+목표:
+- 현재 DB/배포/마이그레이션 체계를 확인하고 변경 전략 확정
+
+작업:
+1. 운영/스테이징 데이터에서 `job.video_id` 중복 현황 점검
+2. `complete-upload` 호출량, 실패율, 재시도 패턴 확인
+3. 마이그레이션 적용 방식 확정(Flyway/Liquibase/수동)
+
+산출물:
+- 데이터 정리 쿼리/백업 계획
+- 단계별 배포 체크리스트 초안
+
+---
+
+## Phase 1. DB 불변식 잠금 (1~2일)
+
+목표:
+- 중복 삽입을 DB에서 원천 차단
+
+작업:
+1. `job` 테이블 유니크 제약 추가
+   - 기본안: `UNIQUE(video_id)`
+   - 재처리 정책이 필요하면 이후 확장(상태 포함 전략)
+2. `credit_history` 중복 차감 방지 키 추가
+   - 예: `deduction_key` 컬럼 + unique
+   - 규칙: `VIDEO_PROCESSING:{videoId}`
+3. 기존 중복 데이터 정리
+
+코드 반영:
+- `Job` 엔티티에 제약 반영
+- CreditHistory 도메인에 deduction key 생성 규칙 반영
+
+검증:
+- 동시 insert 시 unique violation으로 중복 row 미생성 확인
+
+---
+
+## Phase 2. 멱등 응답 계약 도입 (2~3일)
+
+목표:
+- 동일 요청 재시도를 정상 응답으로 수렴
+
+작업:
+1. `Idempotency-Key` 헤더 수용
+   - `VideoController.completeUpload`에서 헤더 입력
+2. idempotency 저장소 구현
+   - 필드: `key`, `memberId`, `endpoint`, `requestHash`, `statusCode`, `responseBody`, `expiresAt`
+3. 처리 플로우 통합
+   - 시작 시 key 조회 -> hit면 즉시 응답
+   - miss면 처리 후 응답 스냅샷 저장
+4. 키 재사용 오염 방지
+   - 동일 key + 다른 request hash -> `409`
+
+API 계약:
+- 최초 처리 성공: `200`
+- 동일 key 재호출: 최초와 동일 body + `200`
+
+검증:
+- timeout 후 재요청 시 동일 응답 반환
+- 동일 key 다른 payload 시 409
+
+---
+
+## Phase 3. Redis 분산락 도입 (1~2일)
+
+목표:
+- 고경합에서 DB 충돌량/예외량 감소
+
+작업:
+1. Redisson 기반 락 서비스 구현
+   - 락 키: `video:complete:{videoId}`
+   - 짧은 wait time + watchdog
+2. `CompleteVideoUploadUseCase`에서 핵심 구간 락 적용
+3. 락 실패 fallback
+   - 즉시 500 금지
+   - idempotency 조회 경로 우선
+
+주의:
+- 락 해제는 소유권 확인
+- 락은 최적화 계층, 정합성 보장은 DB
+
+검증:
+- 경합 테스트에서 lock fail 증가 시에도 정합성 문제 없음
+
+---
+
+## Phase 4. 커밋 후 발행 정렬 (1~2일)
+
+목표:
+- DB 상태와 메시지 발행의 순서 정합성 확보
+
+작업:
+1. `CompleteVideoUploadUseCase`에서 `handleCreate` 직접 호출 제거
+2. `ApplicationEventPublisher.publishEvent(JobCreatedEvent)`로 전환
+3. `@TransactionalEventListener(AFTER_COMMIT)`에서만 SQS 전송
+4. (선택) Outbox로 확장 가능한 포인트 분리
+
+검증:
+- 트랜잭션 롤백 시 메시지 미발행 재현 확인
+
+---
+
+## Phase 5. 테스트 확장 및 운영 배포 (2~3일)
+
+목표:
+- 기능/성능/운영성 모두 검증 후 안전 배포
+
+테스트 추가:
+1. 동시성: 동일 `videoId` + 다중 스레드 + 동일/상이 key 조합
+2. 재시도: 클라이언트 타임아웃 후 재전송
+3. 장애: Redis down, SQS 지연/실패
+4. 롤백: DB 예외 주입 후 메시지 상태 확인
+
+관측 지표:
+- `complete_upload.lock.acquire.success/fail`
+- `complete_upload.idempotency.hit`
+- `complete_upload.db.unique_violation`
+- `complete_upload.duration.p95/p99`
+
+배포 방식:
+1. 카나리(소수 트래픽)
+2. 지표 확인
+3. 점진 확대
+
+롤백 기준:
+- p95 지연 급증
+- 5xx 비율 상승
+- 비정상 unique violation 폭증
+
+---
+
+## 5. 상세 설계 메모
+
+## 5.1 멱등 키 TTL
+
+- 권장: 24시간(초기)
+- 이유: 모바일 재시도 창구를 넉넉히 커버
+- 운영 중 저장 용량/히트율 보고 조정
+
+## 5.2 상태 기반 응답 수렴
+
+`video.status`가 아래면 멱등 성공으로 응답 가능:
+- `UPLOAD_COMPLETED`, `QUEUED`, `PROCESSING`, `COMPLETED`
+
+정책:
+- 비즈니스 에러(권한 불일치, video 미존재)만 실패
+- 중복 호출은 가능하면 성공으로 수렴
+
+## 5.3 크레딧 안정성
+
+- 차감과 Job 생성을 같은 트랜잭션으로 묶고
+- 차감 이력에 중복 방지 키를 부여
+- 실패 시 보상/환불 규칙을 같은 키 기반으로 추적
+
+---
+
+## 6. 리스크와 대응
+
+리스크 1: 스키마 변경 중 잠금/다운타임
+- 대응: 오프피크 적용, 사전 인덱스 생성 전략, 백업/롤백 쿼리
+
+리스크 2: 멱등 저장소 누락으로 재시도 실패
+- 대응: 처리 성공 직전 저장이 아닌, 트랜잭션 내 원자 저장
+
+리스크 3: Redis 장애 시 처리 지연
+- 대응: DB 중심 fallback, 락 실패 시 재조회 응답 정책
+
+리스크 4: 기존 클라이언트 헤더 미전송
+- 대응: 초기에는 서버 생성 key 허용, 이후 필수화 단계적 전환
+
+---
+
+## 7. 실행 순서(요약)
+
+1. DB 유니크/중복 방지 키 적용
+2. Idempotency-Key 계약 및 저장소 구현
+3. Redis 락 추가
+4. 커밋 후 발행 구조 정리
+5. 테스트/메트릭/카나리 배포
+
+핵심 원칙:
+- 정합성(불변식) 먼저, 성능 최적화는 그 다음
+
+---
+
+## 8. 예상 일정
+
+- 총 7~12영업일 (환경/리뷰/배포 승인 포함)
+  - Phase 0: 0.5~1d
+  - Phase 1: 1~2d
+  - Phase 2: 2~3d
+  - Phase 3: 1~2d
+  - Phase 4: 1~2d
+  - Phase 5: 2~3d
+
+---
+
+## 9. 최종 한 줄
+
+이 플랜은 "중복 요청을 막는다"가 아니라, "중복 요청이 와도 시스템이 흔들리지 않고 동일 결과로 수렴한다"를 목표로 한 프로덕션 설계 플랜이다.

--- a/plan/redis-distributed-lock-idempotency-plan.md
+++ b/plan/redis-distributed-lock-idempotency-plan.md
@@ -1,0 +1,656 @@
+# EchoShotX 비디오 업로드 처리 아키텍처 개선 보고서
+## Redis 분산락 + 멱등성 처리 도입 계획
+
+---
+
+## 1. 문제 상황 (Problem Statement)
+
+### 1.1 현재 아키텍처 개요
+
+사용자가 Presigned URL을 통해 S3에 영상 업로드를 완료하면, `CompleteVideoUploadUseCase`가 호출된다. 이 UseCase는 단일 `@Transactional` 트랜잭션 안에서 아래 작업을 **순차적으로 모두 처리**한다.
+
+```
+[클라이언트 요청]
+       │
+       ▼
+@Transactional 트랜잭션 시작 (DB 커넥션 점유 시작)
+       │
+       ├─ 1. DB: Video 비관적 락(PESSIMISTIC_WRITE) 획득
+       ├─ 2. DB: Video 상태 검증
+       ├─ 3. DB: Video 업로드 완료 처리 (상태 변경)
+       ├─ 4. DB: 크레딧 차감 (Credit 테이블 UPDATE)
+       ├─ 5. DB: Job 생성 (Job 테이블 INSERT)
+       ├─ 6. Network I/O: SQS 메시지 전송 ← ⚠️ 핵심 문제
+       └─ 7. DB: Video 상태 QUEUED로 변경
+       │
+트랜잭션 커밋 → DB 커넥션 반환
+```
+
+**문제 핵심:** DB 커넥션을 점유한 채로 외부 네트워크 I/O(SQS)를 수행하고 있다.
+
+---
+
+### 1.2 면접관이 지적한 3가지 치명적 결함
+
+#### 결함 1: DB 커넥션 풀 고갈로 인한 장애 전파
+
+```
+[현재 구조]
+DB 커넥션 점유 시작
+    ├── Video 락 (수 ms)
+    ├── Credit 차감 (수 ms)
+    ├── Job 생성 (수 ms)
+    └── SQS 전송 대기... (최대 수 초, 재시도 포함 수십 초) ← 커넥션 계속 점유
+DB 커넥션 반환
+```
+
+- SQS가 일시적으로 응답 지연(네트워크 레이턴시, AWS 장애)되면, DB 커넥션이 최대 **수십 초** 이상 반환되지 않는다.
+- HikariCP 기본 커넥션 풀은 10개. 동시 요청이 10개만 쌓여도 **전체 서버가 응답 불가** 상태가 된다.
+- SQS 장애 하나가 DB 장애로 전파되고, DB 장애가 전체 서비스 장애로 전파되는 **연쇄 장애(Cascade Failure)** 가 발생한다.
+
+#### 결함 2: 크레딧 이중 차감 위험
+
+```
+[타임라인]
+T1: 요청A → 락 획득 → 크레딧 차감 → SQS 전송 타임아웃
+T2: 요청A → 재시도 → 락 획득 → 크레딧 차감 (이중 차감!) → SQS 전송 성공
+```
+
+- 락 획득은 성공하지만 SQS 전송에서 타임아웃이 발생하면, 트랜잭션 롤백 여부에 따라 크레딧이 차감된 상태로 남을 수 있다.
+- 클라이언트가 실패로 인식하고 재시도하면, **크레딧이 두 번 차감**될 수 있다.
+- 결제/크레딧 도메인에서 이중 차감은 가장 심각한 데이터 정합성 오류다.
+
+#### 결함 3: 다중 테이블 비관적 락으로 인한 데드락 가능성
+
+```
+[데드락 시나리오]
+요청A: Video(id=1) 락 → Credit(userId=10) 락 시도
+요청B: Credit(userId=10) 락 → Video(id=1) 락 시도
+→ 교착 상태 (Deadlock)
+```
+
+- Video, Credit, Job 등 여러 테이블을 순차적으로 락하는 구조는 요청 순서가 다른 경우 데드락을 유발한다.
+- DB 레벨 비관적 락은 교착 상태 감지 후 강제 롤백이 발생하며, 사용자 요청이 무작위로 실패한다.
+
+---
+
+## 2. 원인 분석 (Root Cause Analysis)
+
+| 구분 | 원인 |
+|------|------|
+| **설계적 원인** | 트랜잭션 경계가 지나치게 넓음. DB 작업과 네트워크 I/O가 동일 트랜잭션 안에 묶여 있음 |
+| **동시성 전략** | 분산 환경을 고려하지 않은 단순 DB 비관적 락 사용 |
+| **멱등성 부재** | 동일 요청의 재시도를 구분하는 식별자가 없어, 중복 처리 방지 불가 |
+| **트랜잭션 설계** | 외부 시스템(SQS) 호출이 트랜잭션 원자성 범위에 포함되어, 트랜잭션 의미 자체가 깨짐 |
+
+---
+
+## 3. 개선 방안 (Solution Design)
+
+### 3.1 핵심 전략
+
+```
+비관적 락(DB Lock) → Redis 분산락 (Network Layer)
+이중 처리 문제     → Redis 멱등성 키 (Idempotency Key)
+트랜잭션 경계      → DB 작업 완료 후 이벤트 발행 (@TransactionalEventListener AFTER_COMMIT)
+```
+
+### 3.2 전체 아키텍처 변경
+
+```
+[개선된 구조]
+
+[클라이언트 요청 - Idempotency-Key 헤더 포함]
+       │
+       ▼
+[Redis] 멱등성 키 확인
+  ├─ 이미 처리됨 → 저장된 응답 즉시 반환 (200 OK)
+  └─ 처음 요청 → 계속 진행
+       │
+       ▼
+[Redis] 분산락 시도 (video:{videoId}:lock)
+  ├─ 락 획득 실패 (다른 서버가 처리 중) → 409 Conflict 반환
+  └─ 락 획득 성공 → 계속 진행
+       │
+       ▼
+@Transactional 트랜잭션 시작 (DB 커넥션 점유 시작)
+  ├─ 1. DB: Video 상태 검증 (락 없이 SELECT)
+  ├─ 2. DB: Video 업로드 완료 처리 (상태 변경)
+  ├─ 3. DB: 크레딧 차감
+  ├─ 4. DB: Job 생성
+  └─ 5. ApplicationEventPublisher.publishEvent(JobCreatedEvent)
+       │
+트랜잭션 커밋 → DB 커넥션 즉시 반환 ← ⭐ 핵심 개선
+       │
+       ▼ (트랜잭션 커밋 이후)
+@TransactionalEventListener(AFTER_COMMIT)
+  └─ 6. Network I/O: SQS 메시지 전송 (DB 커넥션과 무관)
+       │
+       ▼
+[Redis] 멱등성 키에 처리 완료 + 응답 저장 (TTL: 24h)
+       │
+       ▼
+[Redis] 분산락 해제
+```
+
+---
+
+## 4. 상세 구현 계획 (Implementation Plan)
+
+### 4.1 의존성 추가
+
+```gradle
+// build.gradle
+implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+```
+
+### 4.2 Redis 분산락 구현
+
+#### `RedisDistributedLockService.java`
+
+```java
+package com.example.echoshotx.shared.lock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisDistributedLockService {
+
+    private final RedissonClient redissonClient;
+
+    private static final long WAIT_TIME_SECONDS = 0L;   // 대기하지 않고 즉시 실패
+    private static final long LEASE_TIME_SECONDS = 10L; // 10초 후 자동 해제 (데드락 방지)
+
+    /**
+     * 분산락을 획득하고 작업을 실행한다.
+     * 락 획득 실패 시 LockAcquisitionFailedException을 던진다.
+     *
+     * @param lockKey  락 키 (예: "video:123:upload-complete")
+     * @param supplier 락 안에서 실행할 작업
+     */
+    public <T> T executeWithLock(String lockKey, Supplier<T> supplier) {
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean acquired = false;
+
+        try {
+            acquired = lock.tryLock(WAIT_TIME_SECONDS, LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+
+            if (!acquired) {
+                log.warn("Failed to acquire distributed lock. key={}", lockKey);
+                throw new LockAcquisitionFailedException("이미 처리 중인 요청입니다. key=" + lockKey);
+            }
+
+            log.debug("Distributed lock acquired. key={}", lockKey);
+            return supplier.get();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LockAcquisitionFailedException("락 획득 중 인터럽트 발생", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.debug("Distributed lock released. key={}", lockKey);
+            }
+        }
+    }
+
+    public static String videoUploadLockKey(Long videoId) {
+        return "video:" + videoId + ":upload-complete";
+    }
+}
+```
+
+#### `LockAcquisitionFailedException.java`
+
+```java
+package com.example.echoshotx.shared.lock;
+
+public class LockAcquisitionFailedException extends RuntimeException {
+    public LockAcquisitionFailedException(String message) {
+        super(message);
+    }
+    public LockAcquisitionFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+```
+
+---
+
+### 4.3 멱등성 처리 구현
+
+#### `IdempotencyService.java`
+
+```java
+package com.example.echoshotx.shared.idempotency;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class IdempotencyService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final Duration IDEMPOTENCY_TTL = Duration.ofHours(24);
+    private static final String PREFIX = "idempotency:";
+
+    /**
+     * 이미 처리된 요청인지 확인하고, 처리된 경우 저장된 응답을 반환한다.
+     */
+    public <T> Optional<T> findProcessedResponse(String idempotencyKey, Class<T> responseType) {
+        String redisKey = PREFIX + idempotencyKey;
+        String stored = redisTemplate.opsForValue().get(redisKey);
+
+        if (stored == null) {
+            return Optional.empty();
+        }
+
+        try {
+            T response = objectMapper.readValue(stored, responseType);
+            log.info("Idempotent response found. key={}", idempotencyKey);
+            return Optional.of(response);
+        } catch (Exception e) {
+            log.warn("Failed to deserialize idempotent response. key={}", idempotencyKey, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 처리 완료된 응답을 저장한다.
+     */
+    public void saveResponse(String idempotencyKey, Object response) {
+        String redisKey = PREFIX + idempotencyKey;
+        try {
+            String serialized = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(redisKey, serialized, IDEMPOTENCY_TTL);
+            log.info("Idempotent response saved. key={}", idempotencyKey);
+        } catch (Exception e) {
+            // 멱등성 저장 실패는 치명적 오류가 아님. 로깅 후 계속 진행
+            log.warn("Failed to save idempotent response. key={}", idempotencyKey, e);
+        }
+    }
+}
+```
+
+---
+
+### 4.4 개선된 UseCase
+
+#### `CompleteVideoUploadUseCase.java` (개선 버전)
+
+```java
+package com.example.echoshotx.video.application.usecase;
+
+import com.example.echoshotx.credit.application.service.CreditService;
+import com.example.echoshotx.job.application.event.JobCreatedEvent;
+import com.example.echoshotx.job.application.service.JobService;
+import com.example.echoshotx.job.domain.entity.Job;
+import com.example.echoshotx.member.domain.entity.Member;
+import com.example.echoshotx.shared.annotation.usecase.UseCase;
+import com.example.echoshotx.shared.idempotency.IdempotencyService;
+import com.example.echoshotx.shared.lock.RedisDistributedLockService;
+import com.example.echoshotx.video.application.adaptor.VideoAdaptor;
+import com.example.echoshotx.video.application.service.VideoService;
+import com.example.echoshotx.video.domain.entity.Video;
+import com.example.echoshotx.video.domain.entity.VideoStatus;
+import com.example.echoshotx.video.domain.exception.VideoErrorStatus;
+import com.example.echoshotx.video.domain.vo.VideoMetadata;
+import com.example.echoshotx.video.presentation.dto.request.CompleteUploadRequest;
+import com.example.echoshotx.video.presentation.dto.response.CompleteUploadResponse;
+import com.example.echoshotx.video.presentation.exception.VideoHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class CompleteVideoUploadUseCase {
+
+    private final VideoAdaptor videoAdaptor;
+    private final VideoService videoService;
+    private final CreditService creditService;
+    private final JobService jobService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final RedisDistributedLockService lockService;
+    private final IdempotencyService idempotencyService;
+
+    /**
+     * @param idempotencyKey 클라이언트가 헤더로 전달하는 멱등성 키 (예: UUID)
+     */
+    public CompleteUploadResponse execute(
+            Long videoId,
+            CompleteUploadRequest request,
+            Member member,
+            String idempotencyKey) {
+
+        // 1. 멱등성 확인: 이미 처리된 요청이면 저장된 응답을 즉시 반환
+        if (idempotencyKey != null) {
+            var cached = idempotencyService.findProcessedResponse(
+                idempotencyKey, CompleteUploadResponse.class
+            );
+            if (cached.isPresent()) {
+                log.info("Returning idempotent response. videoId={}, key={}", videoId, idempotencyKey);
+                return cached.get();
+            }
+        }
+
+        // 2. Redis 분산락 획득 → 중복 요청 차단
+        String lockKey = RedisDistributedLockService.videoUploadLockKey(videoId);
+        CompleteUploadResponse response = lockService.executeWithLock(lockKey, () -> processUpload(request, videoId, member));
+
+        // 3. 처리 완료 후 멱등성 응답 저장
+        if (idempotencyKey != null) {
+            idempotencyService.saveResponse(idempotencyKey, response);
+        }
+
+        return response;
+    }
+
+    /**
+     * 실제 비즈니스 처리 로직.
+     * 분산락 안에서 호출되며, 트랜잭션은 이 메서드에 국한된다.
+     * SQS 전송은 트랜잭션 커밋 이후 이벤트로 처리된다.
+     */
+    @Transactional
+    public CompleteUploadResponse processUpload(CompleteUploadRequest request, Long videoId, Member member) {
+        // 1. 비디오 조회 및 권한 검증 (비관적 락 제거 → 분산락으로 대체)
+        Video video = videoAdaptor.queryById(videoId); // 일반 SELECT
+        video.validateMember(member);
+
+        // 2. 상태 검증 (멱등성 키가 없는 직접 재처리 방지)
+        if (video.getStatus() != VideoStatus.PENDING_UPLOAD) {
+            throw new VideoHandler(VideoErrorStatus.VIDEO_ALREADY_PROCESSED);
+        }
+
+        // 3. 업로드 완료 처리
+        VideoMetadata metadata = createVideoMetadata(request);
+        video = videoService.completeUpload(video, metadata);
+
+        // 4. 크레딧 차감
+        creditService.useCreditsForVideoProcessing(member, video, video.getProcessingType());
+
+        // 5. Job 생성
+        Job job = jobService.createJob(
+            member, video.getId(),
+            video.getOriginalFile().getS3Key(),
+            video.getProcessingType()
+        );
+
+        // 6. 이벤트 발행 (SQS 전송은 AFTER_COMMIT 이후에 실행됨 → DB 커넥션 반환 후)
+        eventPublisher.publishEvent(JobCreatedEvent.builder()
+            .jobId(job.getId())
+            .videoId(job.getVideoId())
+            .processingType(job.getProcessingType())
+            .memberId(member.getId())
+            .s3Key(job.getS3Key())
+            .build());
+
+        // 7. 대기열 상태로 변경
+        video = videoService.enqueueForProcessing(video, null); // sqsMessageId는 이벤트 핸들러에서 업데이트
+
+        log.info("Video upload processing completed. videoId={}, jobId={}", videoId, job.getId());
+        return CompleteUploadResponse.from(video);
+
+        // 트랜잭션 커밋 → DB 커넥션 즉시 반환
+        // 이후 JobEventHandler.handleCreate()가 AFTER_COMMIT 타이밍에 SQS 전송 수행
+    }
+
+    private VideoMetadata createVideoMetadata(CompleteUploadRequest request) {
+        return VideoMetadata.builder()
+            .durationSeconds(request.getDurationSeconds())
+            .width(request.getWidth())
+            .height(request.getHeight())
+            .codec(request.getCodec())
+            .bitrate(request.getBitrate())
+            .frameRate(request.getFrameRate())
+            .build();
+    }
+}
+```
+
+---
+
+### 4.5 개선된 JobEventHandler
+
+#### `JobEventHandler.java` (SQS 실패 시 Job 상태 업데이트 포함)
+
+```java
+package com.example.echoshotx.job.application.handler;
+
+import com.example.echoshotx.job.application.event.JobCreatedEvent;
+import com.example.echoshotx.job.application.service.JobService;
+import com.example.echoshotx.job.infrastructure.dto.JobMessage;
+import com.example.echoshotx.job.infrastructure.publisher.JobPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JobEventHandler {
+
+    private final JobPublisher jobPublisher;
+    private final JobService jobService;
+
+    /**
+     * AFTER_COMMIT: DB 트랜잭션이 완전히 커밋된 이후에 실행.
+     * 이 시점에는 DB 커넥션이 이미 반환된 상태이므로, SQS 전송이 느려도 커넥션 풀에 영향 없음.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCreate(JobCreatedEvent event) {
+        log.info("Publishing SQS message after commit. jobId={}, videoId={}", event.getJobId(), event.getVideoId());
+
+        JobMessage message = JobMessage.builder()
+            .jobId(event.getJobId())
+            .videoId(event.getVideoId())
+            .processingType(event.getProcessingType().name())
+            .memberId(event.getMemberId())
+            .s3Key(event.getS3Key())
+            .build();
+
+        try {
+            jobPublisher.sendWithRetry(message);
+            log.info("SQS message published successfully. jobId={}", event.getJobId());
+        } catch (Exception e) {
+            // SQS 전송 최종 실패 시 → recover()에서 Job 상태를 SEND_FAILED로 마킹
+            // 별도 배치/운영팀 재처리 대상이 됨
+            log.error("SQS message publish failed permanently. jobId={}", event.getJobId(), e);
+        }
+    }
+}
+```
+
+---
+
+### 4.6 컨트롤러: Idempotency-Key 헤더 수신
+
+#### `VideoController.java` (멱등성 키 수신 부분)
+
+```java
+@PostMapping("/{videoId}/complete-upload")
+public ResponseEntity<CompleteUploadResponse> completeUpload(
+        @PathVariable Long videoId,
+        @RequestBody CompleteUploadRequest request,
+        @AuthenticationPrincipal MemberPrincipal principal,
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey) {
+
+    Member member = memberService.findById(principal.getId());
+    CompleteUploadResponse response = completeVideoUploadUseCase.execute(videoId, request, member, idempotencyKey);
+    return ResponseEntity.ok(response);
+}
+```
+
+---
+
+### 4.7 Redis 설정
+
+#### `RedisConfig.java`
+
+```java
+package com.example.echoshotx.shared.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress("redis://" + host + ":" + port)
+            .setConnectionPoolSize(10)
+            .setConnectionMinimumIdleSize(2);
+        return Redisson.create(config);
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory factory) {
+        return new StringRedisTemplate(factory);
+    }
+}
+```
+
+---
+
+## 5. 개선 전/후 비교 (Before vs After)
+
+### 5.1 구조 비교
+
+| 항목 | 개선 전 | 개선 후 |
+|------|---------|---------|
+| **동시성 제어** | DB 비관적 락 (`SELECT ... FOR UPDATE`) | Redis 분산락 (Redisson, tryLock 0초 대기) |
+| **SQS 전송 타이밍** | 트랜잭션 안에서 동기 전송 | 트랜잭션 커밋 이후 (`AFTER_COMMIT`) 이벤트 기반 |
+| **DB 커넥션 점유 시간** | DB 작업 + SQS 네트워크 대기 포함 | DB 작업만 (수 ms 수준) |
+| **멱등성 처리** | 없음 (재시도 시 중복 처리 가능) | Redis 기반 멱등성 키 (24h TTL) |
+| **크레딧 이중 차감** | 재시도 시 발생 가능 | 멱등성 키로 원천 차단 |
+| **데드락 가능성** | 다중 테이블 락으로 높음 | 없음 (DB 락 미사용) |
+| **분산 환경 지원** | 단일 서버 기준으로만 안전 | 다중 서버 환경에서도 안전 |
+
+### 5.2 장애 시나리오 비교
+
+| 시나리오 | 개선 전 결과 | 개선 후 결과 |
+|----------|-------------|-------------|
+| SQS 응답 3초 지연 | DB 커넥션 3초 점유 → 풀 고갈 위험 | 커넥션 이미 반환됨 → 영향 없음 |
+| 클라이언트 중복 요청 | 크레딧 이중 차감 가능 | 멱등성 키로 캐시된 응답 반환 |
+| 서버 2대 동시 요청 처리 | 두 서버 모두 처리 시작 가능 | Redis 분산락으로 하나만 처리 |
+| SQS 전송 최종 실패 | Job 상태 불일치 가능 | `markSendFailed()` 호출 → 재처리 가능 상태로 마킹 |
+
+---
+
+## 6. 성과 (Expected Outcomes)
+
+### 6.1 기술적 성과
+
+**커넥션 풀 안정성**
+- DB 커넥션 점유 시간: 트랜잭션 내 DB 작업 시간만 (기존 대비 90% 이상 단축 추정)
+- SQS 장애가 DB 커넥션 풀에 미치는 영향: 0
+
+**데이터 정합성**
+- 크레딧 이중 차감: 멱등성 키로 원천 차단 (재시도 시 캐시된 응답 반환)
+- 중복 Job 생성: Redis 분산락 + Video 상태 검증 이중 방어
+
+**시스템 신뢰성**
+- 데드락 가능성: DB 비관적 락 제거로 해소
+- 분산 서버 환경 지원: Redis 분산락으로 다중 서버에서도 정확히 1회 처리 보장
+
+### 6.2 아키텍처 개선
+
+- **관심사 분리**: DB 트랜잭션 로직 ↔ 외부 시스템 연동 로직이 명확히 분리됨
+- **확장성**: 향후 서버 증설 시에도 동시성 문제 없이 수평 확장 가능
+- **운영성**: SQS 전송 실패 시 `SEND_FAILED` 상태로 명시적 마킹 → 재처리 파이프라인 구성 가능
+
+---
+
+## 7. 구현 우선순위 및 일정
+
+| 단계 | 작업 | 우선순위 |
+|------|------|---------|
+| 1단계 | Redis 의존성 추가 및 `RedisConfig` 설정 | 즉시 |
+| 2단계 | `RedisDistributedLockService` 구현 | 즉시 |
+| 3단계 | `CompleteVideoUploadUseCase`에서 DB 비관적 락 제거 + 분산락 적용 | 즉시 |
+| 4단계 | `IdempotencyService` 구현 | 1주 내 |
+| 5단계 | 컨트롤러에 `Idempotency-Key` 헤더 수신 추가 | 1주 내 |
+| 6단계 | 통합 테스트 (동시 요청 시나리오, SQS 장애 시나리오) | 2주 내 |
+
+---
+
+## 8. 예외 및 엣지 케이스 처리
+
+### 8.1 Redis 자체가 장애인 경우
+
+```java
+// RedisDistributedLockService에서 Redis 연결 실패 시
+// 옵션 A: DB 비관적 락으로 Fallback (안전 우선)
+// 옵션 B: 예외를 던져 요청 거절 (정합성 우선) ← 권장
+```
+
+결제/크레딧 도메인 특성상 **옵션 B(요청 거절)** 를 권장한다. Redis 장애 시 5xx를 반환하고, 클라이언트가 재시도하도록 유도하는 것이 이중 과금보다 낫다.
+
+### 8.2 Idempotency-Key 없이 요청하는 경우
+
+- 헤더 없는 요청도 처리는 가능하나, 멱등성 보장이 안 됨을 클라이언트에 명시
+- 선택적으로 `required = true`로 변경하여 강제화 가능
+
+### 8.3 멱등성 키 재사용 공격 (보안)
+
+- 멱등성 키에 `memberId`를 포함시켜 타인의 키를 재사용하지 못하도록 방어
+
+```java
+// 멱등성 키 네임스페이스 예시
+String redisKey = "idempotency:" + member.getId() + ":" + idempotencyKey;
+```
+
+---
+
+## 9. 결론
+
+이번 개선은 단순한 기술 교체가 아니라, **분산 시스템에서의 올바른 트랜잭션 설계 원칙**을 적용하는 작업이다.
+
+> "트랜잭션은 가능한 짧게. 외부 시스템 호출은 트랜잭션 밖에서."
+
+Redis 분산락과 멱등성 처리를 도입함으로써, 커넥션 풀 고갈·크레딧 이중 차감·데드락이라는 세 가지 치명적 결함을 동시에 해소하고, 분산 서버 환경에서도 안정적으로 동작하는 구조를 갖추게 된다.

--- a/src/main/java/com/example/echoshotx/credit/application/service/CreditService.java
+++ b/src/main/java/com/example/echoshotx/credit/application/service/CreditService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CreditService {
 
+    private static final String VIDEO_PROCESSING_DEDUCTION_KEY_PREFIX = "VIDEO_PROCESSING:";
+
     private final MemberAdaptor memberAdaptor;
     private final CreditHistoryRepository creditHistoryRepository;
 
@@ -35,7 +37,13 @@ public class CreditService {
         member.useCredits(requiredCredits);
 
         // 사용 내역 기록
-        CreditHistory creditHistory = CreditHistory.createUsage(member.getId(), video.getId(), requiredCredits, processingType);
+        String deductionKey = VIDEO_PROCESSING_DEDUCTION_KEY_PREFIX + video.getId();
+        CreditHistory creditHistory = CreditHistory.createUsage(
+                member.getId(),
+                video.getId(),
+                requiredCredits,
+                processingType,
+                deductionKey);
         return creditHistoryRepository.save(creditHistory);
     }
 

--- a/src/main/java/com/example/echoshotx/credit/domain/entity/CreditHistory.java
+++ b/src/main/java/com/example/echoshotx/credit/domain/entity/CreditHistory.java
@@ -16,6 +16,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
     name = "credit_history",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_credit_history_deduction_key", columnNames = "deduction_key")
+    },
     indexes = {
         @Index(name = "idx_credit_history_member_id", columnList = "member_id"),
         @Index(name = "idx_credit_history_created_date", columnList = "created_date"),
@@ -48,13 +51,17 @@ public class CreditHistory extends BaseTimeEntity {
     @Column(length = 500)
     private String description;
 
+    @Column(name = "deduction_key", length = 120)
+    private String deductionKey;
+
     // business
     
     /**
      * 크레딧 사용 내역 생성
      */
-    public static CreditHistory createUsage(Long memberId, Long videoId, 
-                                          Integer amount, ProcessingType processingType) {
+    public static CreditHistory createUsage(Long memberId, Long videoId,
+                                          Integer amount, ProcessingType processingType,
+                                          String deductionKey) {
         String description = String.format("%s 영상 처리", processingType.getDescription());
         
         return CreditHistory.builder()
@@ -64,6 +71,7 @@ public class CreditHistory extends BaseTimeEntity {
                 .videoId(videoId)
                 .processingType(processingType)
                 .description(description)
+                .deductionKey(deductionKey)
                 .build();
     }
 

--- a/src/main/java/com/example/echoshotx/job/domain/entity/Job.java
+++ b/src/main/java/com/example/echoshotx/job/domain/entity/Job.java
@@ -11,6 +11,12 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(
+        name = "job",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_job_video_id", columnNames = "video_id")
+        }
+)
 public class Job extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/example/echoshotx/shared/redis/service/RedisLockService.java
+++ b/src/main/java/com/example/echoshotx/shared/redis/service/RedisLockService.java
@@ -1,0 +1,33 @@
+package com.example.echoshotx.shared.redis.service;
+
+import java.time.Duration;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisLockService {
+
+    private static final String UNLOCK_LUA_SCRIPT =
+            "if redis.call('get', KEYS[1]) == ARGV[1] then "
+                    + "return redis.call('del', KEYS[1]) "
+                    + "else return 0 end";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public boolean tryLock(String key, String token, Duration ttl) {
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, token, ttl);
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    public void unlock(String key, String token) {
+        DefaultRedisScript<Long> unlockScript = new DefaultRedisScript<>();
+        unlockScript.setScriptText(UNLOCK_LUA_SCRIPT);
+        unlockScript.setResultType(Long.class);
+
+        redisTemplate.execute(unlockScript, Collections.singletonList(key), token);
+    }
+}

--- a/src/main/java/com/example/echoshotx/video/application/service/VideoUploadIdempotencyService.java
+++ b/src/main/java/com/example/echoshotx/video/application/service/VideoUploadIdempotencyService.java
@@ -1,0 +1,138 @@
+package com.example.echoshotx.video.application.service;
+
+import com.example.echoshotx.video.domain.entity.VideoUploadIdempotencyRecord;
+import com.example.echoshotx.video.domain.exception.VideoErrorStatus;
+import com.example.echoshotx.video.infrastructure.persistence.VideoUploadIdempotencyRepository;
+import com.example.echoshotx.video.presentation.dto.request.CompleteUploadRequest;
+import com.example.echoshotx.video.presentation.dto.response.CompleteUploadResponse;
+import com.example.echoshotx.video.presentation.exception.VideoHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class VideoUploadIdempotencyService {
+
+    private static final int SUCCESS_STATUS = 200;
+    private static final long DEFAULT_TTL_HOURS = 24L;
+
+    private final VideoUploadIdempotencyRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public String createRequestHash(Long videoId, CompleteUploadRequest request) {
+        String payload =
+                videoId
+                        + ":"
+                        + request.getDurationSeconds()
+                        + ":"
+                        + request.getWidth()
+                        + ":"
+                        + request.getHeight()
+                        + ":"
+                        + request.getCodec()
+                        + ":"
+                        + request.getBitrate()
+                        + ":"
+                        + request.getFrameRate();
+        return sha256(payload);
+    }
+
+    public Optional<CompleteUploadResponse> findSuccessResponse(
+            Long memberId, Long videoId, String idempotencyKey, String requestHash) {
+        Optional<VideoUploadIdempotencyRecord> optionalRecord =
+                repository.findByMemberIdAndVideoIdAndIdempotencyKey(memberId, videoId, idempotencyKey);
+
+        if (optionalRecord.isEmpty()) {
+            return Optional.empty();
+        }
+
+        VideoUploadIdempotencyRecord record = optionalRecord.get();
+        if (record.isExpired(LocalDateTime.now())) {
+            return Optional.empty();
+        }
+
+        if (!record.getRequestHash().equals(requestHash)) {
+            throw new VideoHandler(VideoErrorStatus.VIDEO_IDEMPOTENCY_KEY_CONFLICT);
+        }
+
+        if (record.getResponseStatus() != SUCCESS_STATUS) {
+            return Optional.empty();
+        }
+
+        return Optional.of(readResponse(record.getResponseBody()));
+    }
+
+    @Transactional
+    public void saveSuccessResponse(
+            Long memberId,
+            Long videoId,
+            String idempotencyKey,
+            String requestHash,
+            CompleteUploadResponse response) {
+        String responseBody = writeResponse(response);
+        VideoUploadIdempotencyRecord record =
+                VideoUploadIdempotencyRecord.create(
+                        memberId,
+                        videoId,
+                        idempotencyKey,
+                        requestHash,
+                        SUCCESS_STATUS,
+                        responseBody,
+                        LocalDateTime.now().plusHours(DEFAULT_TTL_HOURS));
+
+        try {
+            repository.save(record);
+        } catch (DataIntegrityViolationException e) {
+            log.info(
+                    "Idempotency record already exists. memberId={}, videoId={}, key={}",
+                    memberId,
+                    videoId,
+                    idempotencyKey);
+            repository.findByMemberIdAndVideoIdAndIdempotencyKey(memberId, videoId, idempotencyKey)
+                    .ifPresent(existing -> {
+                        if (!existing.getRequestHash().equals(requestHash)) {
+                            throw new VideoHandler(VideoErrorStatus.VIDEO_IDEMPOTENCY_KEY_CONFLICT);
+                        }
+                    });
+        }
+    }
+
+    private String writeResponse(CompleteUploadResponse response) {
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            throw new VideoHandler(VideoErrorStatus.VIDEO_IDEMPOTENCY_SERIALIZATION_FAILED);
+        }
+    }
+
+    private CompleteUploadResponse readResponse(String responseBody) {
+        try {
+            return objectMapper.readValue(responseBody, CompleteUploadResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new VideoHandler(VideoErrorStatus.VIDEO_IDEMPOTENCY_DESERIALIZATION_FAILED);
+        }
+    }
+
+    private String sha256(String input) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = messageDigest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new VideoHandler(VideoErrorStatus.VIDEO_IDEMPOTENCY_HASH_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java
+++ b/src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java
@@ -2,12 +2,13 @@ package com.example.echoshotx.video.application.usecase;
 
 import com.example.echoshotx.credit.application.service.CreditService;
 import com.example.echoshotx.job.application.event.JobCreatedEvent;
-import com.example.echoshotx.job.application.handler.JobEventHandler;
 import com.example.echoshotx.job.application.service.JobService;
 import com.example.echoshotx.job.domain.entity.Job;
 import com.example.echoshotx.member.domain.entity.Member;
 import com.example.echoshotx.shared.annotation.usecase.UseCase;
+import com.example.echoshotx.shared.redis.service.RedisLockService;
 import com.example.echoshotx.video.application.adaptor.VideoAdaptor;
+import com.example.echoshotx.video.application.service.VideoUploadIdempotencyService;
 import com.example.echoshotx.video.application.service.VideoService;
 import com.example.echoshotx.video.domain.entity.Video;
 import com.example.echoshotx.video.domain.entity.VideoStatus;
@@ -16,12 +17,16 @@ import com.example.echoshotx.video.domain.vo.VideoMetadata;
 import com.example.echoshotx.video.presentation.dto.request.CompleteUploadRequest;
 import com.example.echoshotx.video.presentation.dto.response.CompleteUploadResponse;
 
+import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.example.echoshotx.video.presentation.exception.VideoHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /**
  * 클라이언트가 S3 업로드 완료 후 호출하는 UseCase.
@@ -39,14 +44,83 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CompleteVideoUploadUseCase {
 
+    private static final Duration REDIS_LOCK_TTL = Duration.ofSeconds(20);
+    private static final String REDIS_LOCK_KEY_PREFIX = "video:complete:";
+
     private final VideoAdaptor videoAdaptor;
     private final VideoService videoService;
     private final CreditService creditService;
     private final JobService jobService;
-    private final JobEventHandler jobEventHandler;
+    private final VideoUploadIdempotencyService idempotencyService;
+    private final RedisLockService redisLockService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CompleteUploadResponse execute(
             Long videoId, CompleteUploadRequest request, Member member) {
+        return execute(videoId, request, member, null);
+    }
+
+    public CompleteUploadResponse execute(
+            Long videoId,
+            CompleteUploadRequest request,
+            Member member,
+            String idempotencyKey) {
+
+        String normalizedKey = normalizeIdempotencyKey(idempotencyKey);
+        String requestHash = null;
+        if (normalizedKey != null) {
+            requestHash = idempotencyService.createRequestHash(videoId, request);
+            Optional<CompleteUploadResponse> cachedResponse =
+                    idempotencyService.findSuccessResponse(
+                            member.getId(), videoId, normalizedKey, requestHash);
+            if (cachedResponse.isPresent()) {
+                return cachedResponse.get();
+            }
+        }
+
+        if (normalizedKey == null) {
+            return processCompleteUpload(videoId, request, member, null, null);
+        }
+
+        String lockKey = REDIS_LOCK_KEY_PREFIX + videoId;
+        String lockToken = UUID.randomUUID().toString();
+        boolean acquired = false;
+
+        try {
+            acquired = redisLockService.tryLock(lockKey, lockToken, REDIS_LOCK_TTL);
+        } catch (RuntimeException e) {
+            log.warn("Redis lock acquire failed. fallback to DB lock. key={}", lockKey, e);
+        }
+
+        if (!acquired) {
+            Optional<CompleteUploadResponse> retryCachedResponse =
+                    idempotencyService.findSuccessResponse(
+                            member.getId(), videoId, normalizedKey, requestHash);
+            if (retryCachedResponse.isPresent()) {
+                return retryCachedResponse.get();
+            }
+            log.info("Redis lock not acquired. continue with DB lock. key={}", lockKey);
+        }
+
+        try {
+            return processCompleteUpload(videoId, request, member, normalizedKey, requestHash);
+        } finally {
+            if (acquired) {
+                try {
+                    redisLockService.unlock(lockKey, lockToken);
+                } catch (RuntimeException e) {
+                    log.warn("Redis unlock failed. key={}", lockKey, e);
+                }
+            }
+        }
+    }
+
+    private CompleteUploadResponse processCompleteUpload(
+            Long videoId,
+            CompleteUploadRequest request,
+            Member member,
+            String normalizedKey,
+            String requestHash) {
 
         // 1. 비디오 조회 및 권한 검증
         Video video = videoAdaptor.queryByIdWithLock(videoId);
@@ -54,7 +128,14 @@ public class CompleteVideoUploadUseCase {
 
         // 2. 상태 검증
         if (video.getStatus() != VideoStatus.PENDING_UPLOAD) {
-            throw new VideoHandler(VideoErrorStatus.VIDEO_ALREADY_PROCESSED);
+            if (normalizedKey == null) {
+                throw new VideoHandler(VideoErrorStatus.VIDEO_ALREADY_PROCESSED);
+            }
+
+            CompleteUploadResponse response = CompleteUploadResponse.from(video);
+            idempotencyService.saveSuccessResponse(
+                    member.getId(), videoId, normalizedKey, requestHash, response);
+            return response;
         }
 
         VideoMetadata metadata = createVideoMetadata(request);
@@ -71,7 +152,14 @@ public class CompleteVideoUploadUseCase {
         // 6. 처리 대기열에 추가 및 알림 발행 (UPLOAD_COMPLETED → QUEUED)
         video = videoService.enqueueForProcessing(video, sqsMessageId);
 
-        return CompleteUploadResponse.from(video);
+        CompleteUploadResponse response = CompleteUploadResponse.from(video);
+
+        if (normalizedKey != null) {
+            idempotencyService.saveSuccessResponse(
+                    member.getId(), videoId, normalizedKey, requestHash, response);
+        }
+
+        return response;
     }
 
     private String sendToProcessingQueue(Member member, Video video) {
@@ -83,9 +171,16 @@ public class CompleteVideoUploadUseCase {
 				.memberId(member.getId())
 				.s3Key(job.getS3Key())
 				.build();
-		jobEventHandler.handleCreate(event);
+		eventPublisher.publishEvent(event);
         // Mock implementation
         return UUID.randomUUID().toString();
+    }
+
+    private String normalizeIdempotencyKey(String idempotencyKey) {
+        if (!StringUtils.hasText(idempotencyKey)) {
+            return null;
+        }
+        return idempotencyKey.trim();
     }
 
     private VideoMetadata createVideoMetadata(CompleteUploadRequest request) {

--- a/src/main/java/com/example/echoshotx/video/domain/entity/VideoUploadIdempotencyRecord.java
+++ b/src/main/java/com/example/echoshotx/video/domain/entity/VideoUploadIdempotencyRecord.java
@@ -1,0 +1,81 @@
+package com.example.echoshotx.video.domain.entity;
+
+import com.example.echoshotx.shared.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(
+        name = "video_upload_idempotency_record",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_video_upload_idempotency_key",
+                        columnNames = {"member_id", "video_id", "idempotency_key"})
+        })
+public class VideoUploadIdempotencyRecord extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "video_id", nullable = false)
+    private Long videoId;
+
+    @Column(name = "idempotency_key", nullable = false, length = 120)
+    private String idempotencyKey;
+
+    @Column(name = "request_hash", nullable = false, length = 128)
+    private String requestHash;
+
+    @Column(name = "response_status", nullable = false)
+    private Integer responseStatus;
+
+    @Lob
+    @Column(name = "response_body", nullable = false)
+    private String responseBody;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    public static VideoUploadIdempotencyRecord create(
+            Long memberId,
+            Long videoId,
+            String idempotencyKey,
+            String requestHash,
+            Integer responseStatus,
+            String responseBody,
+            LocalDateTime expiresAt) {
+        return VideoUploadIdempotencyRecord.builder()
+                .memberId(memberId)
+                .videoId(videoId)
+                .idempotencyKey(idempotencyKey)
+                .requestHash(requestHash)
+                .responseStatus(responseStatus)
+                .responseBody(responseBody)
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt.isBefore(now);
+    }
+}

--- a/src/main/java/com/example/echoshotx/video/domain/exception/VideoErrorStatus.java
+++ b/src/main/java/com/example/echoshotx/video/domain/exception/VideoErrorStatus.java
@@ -43,6 +43,10 @@ public enum VideoErrorStatus implements BaseCode {
     VIDEO_NOT_COMPLETED(BAD_REQUEST, 4330, "비디오 처리가 완료되지 않았습니다."),
     VIDEO_PROCESSED_FILE_NOT_EXISTS(BAD_REQUEST, 4331, "처리된 비디오 파일이 존재하지 않습니다."),
     VIDEO_ALREADY_PROCESSED(BAD_REQUEST, 4332, "이미 처리된 비디오입니다."),
+    VIDEO_IDEMPOTENCY_KEY_CONFLICT(CONFLICT, 4333, "동일한 멱등 키에 다른 요청 본문이 전달되었습니다."),
+    VIDEO_IDEMPOTENCY_SERIALIZATION_FAILED(INTERNAL_SERVER_ERROR, 4334, "멱등 응답 직렬화에 실패했습니다."),
+    VIDEO_IDEMPOTENCY_DESERIALIZATION_FAILED(INTERNAL_SERVER_ERROR, 4335, "멱등 응답 역직렬화에 실패했습니다."),
+    VIDEO_IDEMPOTENCY_HASH_FAILED(INTERNAL_SERVER_ERROR, 4336, "멱등 요청 해시 생성에 실패했습니다."),
 
     // 진행률 관련 에러 (4340 ~ 4350)
     VIDEO_INVALID_STATUS_FOR_PROGRESS_UPDATE(BAD_REQUEST, 4340, "진행률을 업데이트할 수 없는 상태입니다."),

--- a/src/main/java/com/example/echoshotx/video/infrastructure/persistence/VideoUploadIdempotencyRepository.java
+++ b/src/main/java/com/example/echoshotx/video/infrastructure/persistence/VideoUploadIdempotencyRepository.java
@@ -1,0 +1,12 @@
+package com.example.echoshotx.video.infrastructure.persistence;
+
+import com.example.echoshotx.video.domain.entity.VideoUploadIdempotencyRecord;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VideoUploadIdempotencyRepository
+        extends JpaRepository<VideoUploadIdempotencyRecord, Long> {
+
+    Optional<VideoUploadIdempotencyRecord> findByMemberIdAndVideoIdAndIdempotencyKey(
+            Long memberId, Long videoId, String idempotencyKey);
+}

--- a/src/main/java/com/example/echoshotx/video/presentation/controller/VideoController.java
+++ b/src/main/java/com/example/echoshotx/video/presentation/controller/VideoController.java
@@ -80,10 +80,11 @@ public class VideoController {
   public ApiResponseDto<CompleteUploadResponse> completeUpload(
 	  @PathVariable Long videoId,
 	  @Valid @RequestBody CompleteUploadRequest request,
+	  @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
 	  @CurrentMember Member member) {
 
 	CompleteUploadResponse response =
-		completeVideoUploadUseCase.execute(videoId, request, member);
+		completeVideoUploadUseCase.execute(videoId, request, member, idempotencyKey);
 	return ApiResponseDto.onSuccess(response);
   }
 

--- a/src/test/java/com/example/echoshotx/video/application/service/VideoUploadIdempotencyServiceTest.java
+++ b/src/test/java/com/example/echoshotx/video/application/service/VideoUploadIdempotencyServiceTest.java
@@ -1,0 +1,86 @@
+package com.example.echoshotx.video.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.example.echoshotx.video.domain.entity.VideoStatus;
+import com.example.echoshotx.video.domain.entity.VideoUploadIdempotencyRecord;
+import com.example.echoshotx.video.infrastructure.persistence.VideoUploadIdempotencyRepository;
+import com.example.echoshotx.video.presentation.dto.response.CompleteUploadResponse;
+import com.example.echoshotx.video.presentation.exception.VideoHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class VideoUploadIdempotencyServiceTest {
+
+    @Mock
+    private VideoUploadIdempotencyRepository repository;
+
+    private VideoUploadIdempotencyService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VideoUploadIdempotencyService(repository, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("성공: 동일 요청 해시이면 저장된 응답을 반환한다")
+    void findSuccessResponse_ReturnsCachedResponse_WhenHashMatches() {
+        CompleteUploadResponse response =
+                CompleteUploadResponse.builder()
+                        .videoId(10L)
+                        .status(VideoStatus.QUEUED)
+                        .message("영상 처리가 시작되었습니다.")
+                        .sqsMessageId("msg-1")
+                        .build();
+
+        VideoUploadIdempotencyRecord record =
+                VideoUploadIdempotencyRecord.create(
+                        1L,
+                        10L,
+                        "idem-key",
+                        "same-hash",
+                        200,
+                        "{\"videoId\":10,\"status\":\"QUEUED\",\"message\":\"영상 처리가 시작되었습니다.\",\"sqsMessageId\":\"msg-1\"}",
+                        LocalDateTime.now().plusHours(1));
+
+        given(repository.findByMemberIdAndVideoIdAndIdempotencyKey(1L, 10L, "idem-key"))
+                .willReturn(Optional.of(record));
+
+        Optional<CompleteUploadResponse> cached =
+                service.findSuccessResponse(1L, 10L, "idem-key", "same-hash");
+
+        assertThat(cached).isPresent();
+        assertThat(cached.get().getVideoId()).isEqualTo(10L);
+        assertThat(cached.get().getStatus()).isEqualTo(VideoStatus.QUEUED);
+    }
+
+    @Test
+    @DisplayName("실패: 동일 멱등 키에 요청 해시가 다르면 예외가 발생한다")
+    void findSuccessResponse_Throws_WhenHashDiffers() {
+        VideoUploadIdempotencyRecord record =
+                VideoUploadIdempotencyRecord.create(
+                        1L,
+                        10L,
+                        "idem-key",
+                        "old-hash",
+                        200,
+                        "{}",
+                        LocalDateTime.now().plusHours(1));
+
+        given(repository.findByMemberIdAndVideoIdAndIdempotencyKey(1L, 10L, "idem-key"))
+                .willReturn(Optional.of(record));
+
+        assertThatThrownBy(() -> service.findSuccessResponse(1L, 10L, "idem-key", "new-hash"))
+                .isInstanceOf(VideoHandler.class);
+    }
+}


### PR DESCRIPTION
## Summary

이번 PR은 `POST /videos/{videoId}/complete-upload`의 중복 실행 문제를 단순 동시성 이슈가 아니라 **금전성 트랜잭션 + 비동기 발행 + 네트워크 재시도**가 결합된 복합 정합성 문제로 보고, 다음 4축으로 재설계한 변경입니다.

1. **DB 불변식 강제**: 중복 생성/중복 차감을 데이터 계층에서 물리 차단  
2. **API 멱등 계약 도입**: 동일 요청 재시도를 동일 성공 응답으로 수렴  
3. **Redis 분산락 도입(최적화 계층)**: 고경합 시 충돌량과 예외량 완화  
4. **커밋 후 이벤트 발행 정렬**: DB 상태와 메시지 발행 순서 정합성 확보

핵심은 “락을 더 세게”가 아니라,  
**정합성(DB) / 경험(API) / 성능(Redis) / 메시지 일관성(After Commit)**의 책임 분리를 통해 실패 모드를 상호 보완하는 구조로 바꾼 것입니다.

---

## Problem Framing (왜 이 PR이 필요한가)

`complete-upload`는 조회성 API가 아니라 다음 사이드이펙트를 동시에 유발합니다.

- Video 상태 전이 (`PENDING_UPLOAD -> UPLOAD_COMPLETED -> QUEUED`)
- Credit 차감 (금전성 데이터)
- Job 생성 (비동기 파이프라인 진입점)
- SQS 발행

여기서 더블클릭/재전송/네트워크 타임아웃이 결합되면, 단순히 “중복 요청 에러” 문제가 아니라 아래 리스크가 발생합니다.

- Job 중복 생성
- 크레딧 중복 차감
- DB 롤백 vs 메시지 선발행 불일치
- 재시도 시 사용자/클라이언트가 실패로 인식하고 요청 폭증

즉 이 문제의 본질은 “락”이 아니라 **불변식 관리**입니다.

---

## Non-Negotiable Invariants (절대 깨지면 안 되는 것)

- **I1**: 동일 `videoId`에 대해 활성 Job은 최대 1개
- **I2**: 동일 처리에 대해 credit 차감은 최대 1회
- **I3**: DB 커밋 실패 시 외부 큐 메시지가 먼저 나가면 안 됨
- **I4**: 동일 요청 재시도는 실패 폭탄이 아니라 동일 결과로 수렴해야 함

이 PR의 모든 기술 선택은 이 4개 불변식 기준으로 평가했습니다.

---

## Why This Architecture (왜 이 조합이어야 하는가)

### 결론: `Redis Lock + DB Unique + Idempotent Response + After-Commit Publish`

이 조합을 고른 이유는 단일 기법으로는 상충 목표를 동시에 만족시킬 수 없기 때문입니다.

- DB Unique만 쓰면 정합성은 강하지만 고경합에서 예외 폭증/UX 악화
- Redis Lock만 쓰면 성능은 좋지만 정합성 최종 보장 불가
- Idempotency-Key만 쓰면 API 계약은 좋아도 내부 중복 생성 차단 불가
- 비관적 락만 쓰면 동시성 제어는 되나 재시도 계약/최종 불변식 강제력이 약함

즉 **한 가지 기술을 주인공으로 두는 접근은 반드시 빈틈이 생김**.  
이번 PR은 각 계층을 “역할 기반”으로 분리했습니다.

- **DB Unique**: 최종 정합성 보루 (must)
- **Idempotency**: 네트워크 재시도 수렴 (must)
- **Redis Lock**: 앞단 경합 완화 (optimize)
- **After-Commit**: 비동기 정합성 (must)

---

## Alternatives Considered (대안 검토 및 기각 사유)

### 1) Pessimistic Lock only
- 장점: 빠른 도입, 동일 row 직렬화
- 기각 사유:
  - 멱등 API 계약 부재
  - 애플리케이션 경로 누락/버그 시 DB 레벨 중복 차단 부재
  - 고경합 대기/타임아웃 비용 큼

### 2) Redis Lock only
- 장점: 락 획득 빠름, 인스턴스 간 제어
- 기각 사유:
  - 네트워크 분할/TTL 만료/프로세스 중단에서 최종 무결성 보장 불가
  - 락은 데이터 제약을 대체하지 못함

### 3) DB Unique only
- 장점: 강력한 정합성
- 기각 사유:
  - 충돌 시 예외 기반 제어로 UX/운영 비용 증가
  - 재시도 요청 동일 응답 계약 없음

### 4) Idempotency-Key only
- 장점: 재시도 UX 우수
- 기각 사유:
  - 내부 insert 중복을 물리적으로 막지 못함

### 5) Outbox 즉시 도입
- 장점: 발행 내구성 매우 강함
- 이번 PR에서 보류한 이유:
  - 변경 범위/운영 복잡도가 큼
  - 우선 `publishEvent + AFTER_COMMIT` 정렬 후 단계적 도입이 현실적

---

## What Changed (구체 변경)

### 1) DB 불변식 강화
- `job.video_id` 유니크 제약 추가  
  - `src/main/java/com/example/echoshotx/job/domain/entity/Job.java`
- `credit_history.deduction_key` 유니크 제약 + 필드 추가  
  - `src/main/java/com/example/echoshotx/credit/domain/entity/CreditHistory.java`
- 차감 시 비즈니스 키 생성 적용 (`VIDEO_PROCESSING:{videoId}`)  
  - `src/main/java/com/example/echoshotx/credit/application/service/CreditService.java`

### 2) 멱등 응답 계층 도입
- Idempotency 레코드 엔티티/리포지토리/서비스 추가
  - `src/main/java/com/example/echoshotx/video/domain/entity/VideoUploadIdempotencyRecord.java`
  - `src/main/java/com/example/echoshotx/video/infrastructure/persistence/VideoUploadIdempotencyRepository.java`
  - `src/main/java/com/example/echoshotx/video/application/service/VideoUploadIdempotencyService.java`
- `Idempotency-Key` + request hash 비교
  - 동일 키/동일 요청: 기존 성공 응답 재반환
  - 동일 키/다른 요청: 충돌 처리(에러 코드 추가)
- 관련 에러 코드 추가
  - `src/main/java/com/example/echoshotx/video/domain/exception/VideoErrorStatus.java`

### 3) UseCase 오케스트레이션 재구성
- `CompleteVideoUploadUseCase`에서:
  - 멱등 선조회
  - Redis 락 시도
  - 락 실패 시 idempotency 재조회 후 DB 락 경로 fallback
  - `jobEventHandler.handleCreate(...)` 직접 호출 제거
  - `ApplicationEventPublisher.publishEvent(...)` 전환
- 파일:
  - `src/main/java/com/example/echoshotx/video/application/usecase/CompleteVideoUploadUseCase.java`

### 4) API 계약 확장
- 컨트롤러에서 `Idempotency-Key` 헤더 수용
  - `src/main/java/com/example/echoshotx/video/presentation/controller/VideoController.java`

### 5) Redis 분산락 유틸
- `SET NX EX` + Lua unlock(소유 토큰 검증) 구현
  - `src/main/java/com/example/echoshotx/shared/redis/service/RedisLockService.java`

### 6) 테스트/문서
- 멱등 서비스 단위 테스트 추가
  - `src/test/java/com/example/echoshotx/video/application/service/VideoUploadIdempotencyServiceTest.java`
- 분석/구현 문서 보강
  - `docs/complete-upload-idempotency-expert-review.md`
  - `docs/complete-upload-idempotency-implementation-plan.md`

---

## Failure Mode Analysis (엣지 케이스에서 왜 안전한가)

1. **더블 클릭 (ms 단위 동시 요청)**
   - 앞단 Redis 락으로 진입량 완충
   - 최종적으로 DB Unique가 중복 생성 차단

2. **응답 유실 후 재시도**
   - 동일 `Idempotency-Key` hit 시 동일 body 재반환
   - 클라이언트가 “성공했는지 모름” 문제 해결

3. **Redis 장애**
   - 락 최적화 계층만 약화
   - 정합성은 DB Unique + 트랜잭션 경로로 유지

4. **동일 키/다른 payload 오염**
   - request hash 불일치로 충돌 처리
   - 키 재사용 공격/오용 방지

5. **트랜잭션 실패**
   - 이벤트를 커밋 후 처리 경로로 정렬
   - “DB 롤백 + 메시지 선발행” 가능성 축소

6. **크레딧 중복 차감**
   - `deduction_key` 유니크로 물리 차단

---

## Trade-offs (의도적으로 감수한 부분)

- 테이블/엔티티/오케스트레이션 복잡도 증가
- Idempotency 저장 비용(응답 스냅샷 보관)
- Redis 락 관리(토큰, TTL, unlock 실패 로깅) 운영 포인트 증가

그러나 위 비용은 정합성 사고(중복 과금, 중복 처리, 메시지 불일치) 대비 훨씬 작다고 판단했습니다.
